### PR TITLE
Fix multiple targets

### DIFF
--- a/Inc/communication/wakaama_client/objects/object_target.h
+++ b/Inc/communication/wakaama_client/objects/object_target.h
@@ -4,6 +4,9 @@
 
 #include "target.h"
 
+
+extern int JTAG_BUSY;
+extern int USB_BUSY;
 /*
  * Multiple instance objects can use userdata to store data that will be shared between the different instances.
  * The lwm2m_object_t object structure - which represent every object of the liblwm2m as seen in the single instance

--- a/Src/communication/binary_download.c
+++ b/Src/communication/binary_download.c
@@ -30,6 +30,7 @@ static void download_error(target_instance_t *targetP, int err, int socket, char
         lwip_close(socket);
     }
     lwm2m_free(url_str);
+    USB_BUSY = 0;
     vTaskDelete(NULL);
 }
 
@@ -155,12 +156,13 @@ void startDownload(void *object_target) {
     targetP->download_error = NO_ERROR;
     lwip_close(socket);
     lwm2m_free(url_str);
+    USB_BUSY = 0;
     vTaskDelete(NULL);
 }
 
 static uint8_t createFile(target_instance_t *targetP, char *url_str, int socket, FIL *file) {
     if (get_usb_ready()) {
-        int result = usb_open_file(targetP->binary_filename, file, FA_WRITE | FA_CREATE_NEW);
+        int result = usb_open_file(targetP->binary_filename, file, FA_WRITE | FA_CREATE_ALWAYS);
         if (result != 0) {
             download_error(targetP, USB_ERROR, socket, url_str);
         }

--- a/Src/target.c
+++ b/Src/target.c
@@ -27,6 +27,8 @@ void flash_target_task(void *object) {
 	if (result != 0) {
 		target_object->flash_error = USB_FS_ERROR;
 		target_object->flash_state = FLASH_ERROR;
+		JTAG_BUSY = 0;
+		USB_BUSY = 0;
 		vTaskDelete(NULL);
 	}
 
@@ -40,6 +42,8 @@ void flash_target_task(void *object) {
 	}
 	
 	result = usb_close_file(&file);
+	JTAG_BUSY = 0;
+	USB_BUSY = 0;
 	if (result != 0) {
 		target_object->flash_error = USB_FS_ERROR;
 		vTaskDelete(NULL);
@@ -50,5 +54,6 @@ void flash_target_task(void *object) {
 void reset_target_task(void *object) {
 	target_instance_t * target_object = (target_instance_t *) object;
 	target_object->target->ops->reset_target(target_object->target->priv);
+	JTAG_BUSY = 0;
 	vTaskDelete(NULL);	
 }


### PR DESCRIPTION
Added support for multiple targets and fixed race condition for JTAG and USB FAT FS. Changed file names convention for different targets.
This closes #45 