### PR TITLE
Fix memory managment in Wakaama

### DIFF
--- a/Src/communication/wakaama_client/connection.c
+++ b/Src/communication/wakaama_client/connection.c
@@ -92,7 +92,7 @@ connection_t * connection_create(connection_t * connList,
         lwip_close(s);
     }
     if (NULL != servinfo) {
-        lwm2m_free(servinfo);
+        lwip_freeaddrinfo(servinfo);
     }
 
     return connP;

--- a/Src/communication/wakaama_client/platform/platform.c
+++ b/Src/communication/wakaama_client/platform/platform.c
@@ -35,11 +35,11 @@
 #ifdef LWM2M_MEMORY_TRACE
 void * lwm2m_trace_malloc(size_t s, const char * file, const char * function, int lineno) {
   printf("lwm2m_malloc: \"%s\" : \"%s\" : %d \n", file, function, lineno);
-  return mem_malloc(s);
+  return pvPortMalloc(s);
 }
 #else 
 void * lwm2m_malloc(size_t s){
-  return mem_malloc(s);
+  return pvPortMalloc(s);
 }
 #endif
 
@@ -47,11 +47,11 @@ void * lwm2m_malloc(size_t s){
 #ifdef LWM2M_MEMORY_TRACE
 void lwm2m_trace_free(void * p, const char * file, const char * function, int lineno) {
   printf("lwm2m_free: \"%s\" : \"%s\" : %d \n", file, function, lineno);
-  mem_free(p);
+  vPortFree(p);
 }
 #else 
 void lwm2m_free(void * p) {
-  mem_free(p);
+  vPortFree(p);
 }
 #endif
 
@@ -59,12 +59,12 @@ void lwm2m_free(void * p) {
 #ifdef LWM2M_MEMORY_TRACE
 char * lwm2m_trace_strdup(const char * str, const char * file, const char * function, int lineno) {
   printf("lwm2m_strdup: \"%s\" : \"%s\" : %d \n", file, function, lineno);
-  char *dup = mem_malloc(strlen(str) + 1);
+  char *dup = pvPortMalloc(strlen(str) + 1);
   return dup ? strcpy(dup, str) : dup;
 }
 #else
 char * lwm2m_strdup(const char * str) {
-  char *dup = mem_malloc(strlen(str) + 1);
+  char *dup = pvPortMalloc(strlen(str) + 1);
   return dup ? strcpy(dup, str) : dup;
 }
 #endif


### PR DESCRIPTION
There was bug that address obtained by lwip_getaddrinfo() wasn't free
by lwip_freeaddrinfo().

Now we can use FreeRTOS memory managment accross Wakaama and this patch
switch it to that.

This close #14 